### PR TITLE
Add 'key' parameter to GIFImage

### DIFF
--- a/lib/flutter_gifimage.dart
+++ b/lib/flutter_gifimage.dart
@@ -56,7 +56,8 @@ class GifController extends AnimationController{
 
 
 class GifImage extends StatefulWidget{
-  GifImage({
+  const GifImage({
+    Key key,
     @required this.image,
     @required this.controller,
     this.semanticLabel,
@@ -72,7 +73,7 @@ class GifImage extends StatefulWidget{
     this.centerSlice,
     this.matchTextDirection = false,
     this.gaplessPlayback = false,
-  });
+  }) : super(key: key);
   final VoidCallback onFetchCompleted;
   final GifController controller;
   final ImageProvider image;


### PR DESCRIPTION
`Key key` was missing in the constructor for super class. Also made the constructor const because all the properties are final. I came across a use case where I needed the height of the image in some other widget. This requires to pass a `GlobalKey` to the image.

Also, thanks for creating this package!